### PR TITLE
Unset select name if there are no options

### DIFF
--- a/form2request/_base.py
+++ b/form2request/_base.py
@@ -149,7 +149,15 @@ def _data(
     )
     values: list[FormdataKVType] = [
         (k, "" if v is None else v)
-        for k, v in ((e.name, e.value) for e in inputs)
+        for k, v in (
+            (
+                # Unset name for selects without options.
+                (None, None)
+                if e.tag == "select" and not e.value_options
+                else (e.name, e.value)
+            )
+            for e in inputs
+        )
         if k and k not in keys
     ]
     items = data.items() if isinstance(data, dict) else data

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -590,6 +590,30 @@ from form2request import Request, form2request
                 b"",
             ),
         ),
+        # Single-choice select with no options.
+        (
+            "https://example.com",
+            b"""<form><select name="a"></select></form>""",
+            {},
+            Request(
+                "https://example.com",
+                "GET",
+                [],
+                b"",
+            ),
+        ),
+        # Single-choice select with no options but with a value.
+        (
+            "https://example.com",
+            b"""<form><select name="a" value="b"></select></form>""",
+            {},
+            Request(
+                "https://example.com",
+                "GET",
+                [],
+                b"",
+            ),
+        ),
         # Single-choice select with multiple options. The first one is
         # selected.
         (
@@ -654,6 +678,30 @@ from form2request import Request, form2request
             {},
             Request(
                 "https://example.com?a=b&a=c",
+                "GET",
+                [],
+                b"",
+            ),
+        ),
+        # Multiple-choice select without options.
+        (
+            "https://example.com",
+            b"""<form><select multiple name="a"></select></form>""",
+            {},
+            Request(
+                "https://example.com",
+                "GET",
+                [],
+                b"",
+            ),
+        ),
+        # Multiple-choice select without options but with a value.
+        (
+            "https://example.com",
+            b"""<form><select multiple name="a" value="b"></select></form>""",
+            {},
+            Request(
+                "https://example.com",
                 "GET",
                 [],
                 b"",


### PR DESCRIPTION
Detected by web-poet tests posted from Scrapy that I had failed to replicate here. Verified as the expected behavior in Chromium.