### PR TITLE
Ignore disabled elements by default

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -130,16 +130,24 @@ Request(url='https://example.com?foo=bar&foo=baz', method='GET', headers=[], bod
 
 Sometimes, you might want to prevent a value from a field from being included
 in the generated request data. For example, because the field is removed or
-disabled through JavaScript, or because the field or a parent element has the
-``disabled`` attribute (currently not supported by form2request):
+disabled through JavaScript:
 
->>> html = b"""<form><input name="foo" value="bar" disabled /></form>"""
+>>> html = b"""<form><input name="foo" value="bar" /></form>"""
 >>> selector = Selector(body=html, base_url="https://example.com")
 >>> form = selector.css("form")
 
 To remove a field value, set it to ``None``:
 
 >>> form2request(form, {"foo": None})
+Request(url='https://example.com', method='GET', headers=[], body=b'')
+
+Fields with the ``disabled`` attribute, or inside a ``<fieldset disabled>``
+element, are excluded automatically, as browsers do:
+
+>>> html = b"""<form><input name="foo" value="bar" disabled /></form>"""
+>>> selector = Selector(body=html, base_url="https://example.com")
+>>> form = selector.css("form")
+>>> form2request(form)
 Request(url='https://example.com', method='GET', headers=[], body=b'')
 
 
@@ -202,6 +210,17 @@ You can override the method_ and enctype_ attributes of a form:
 >>> form2request(form, method="POST", enctype="text/plain")
 Request(url='https://example.com', method='POST', headers=[('Content-Type', 'text/plain')], body=b'foo=bar')
 
+You can also set ``ignore_disabled=False`` to include disabled fields and
+buttons in the request. This can be useful when a page uses JavaScript to
+enable fields before submission, and the HTML you are parsing reflects the
+pre-JavaScript state:
+
+>>> html = b"""<form><input name="foo" value="bar" disabled /></form>"""
+>>> selector = Selector(body=html, base_url="https://example.com")
+>>> form = selector.css("form")
+>>> form2request(form, ignore_disabled=False)
+Request(url='https://example.com?foo=bar', method='GET', headers=[], body=b'')
+
 
 .. _request:
 
@@ -211,6 +230,9 @@ Using request data
 The output of :func:`~form2request.form2request`,
 :class:`~form2request.Request`, is a simple request data container:
 
+>>> html = b"""<form><input type="submit" name="foo" value="bar" /></form>"""
+>>> selector = Selector(body=html, base_url="https://example.com")
+>>> form = selector.css("form")
 >>> request_data = form2request(form)
 >>> request_data
 Request(url='https://example.com?foo=bar', method='GET', headers=[], body=b'')

--- a/form2request/_base.py
+++ b/form2request/_base.py
@@ -105,8 +105,31 @@ def _method(
     return method
 
 
+def _is_element_disabled(element: HtmlElement) -> bool:
+    """Check if a form element is disabled per the HTML spec.
+
+    An element is disabled if it has the ``disabled`` attribute, or if it is a
+    descendant of a ``fieldset[disabled]`` element and not a descendant of that
+    fieldset's first ``legend`` child.
+    """
+    if element.get("disabled") is not None:
+        return True
+    element_ancestors = set(element.iterancestors())
+    for ancestor in element_ancestors:
+        if ancestor.tag != "fieldset" or ancestor.get("disabled") is None:
+            continue
+        first_legend = next(
+            (child for child in ancestor if child.tag == "legend"), None
+        )
+        if first_legend is None or first_legend not in element_ancestors:
+            return True
+    return False
+
+
 def _click_element(
-    form: FormElement, click: bool | HtmlElement | Selector | SelectorList | None
+    form: FormElement,
+    click: bool | HtmlElement | Selector | SelectorList | None,
+    ignore_disabled: bool,
 ) -> HtmlElement | None:
     if click is False:
         return None
@@ -118,6 +141,8 @@ def _click_element(
                 namespaces={"re": "http://exslt.org/regular-expressions"},
             )
         )
+        if ignore_disabled:
+            clickables = [e for e in clickables if not _is_element_disabled(e)]
         if clickables:
             return clickables[0]
         if click:
@@ -130,7 +155,10 @@ def _click_element(
 
 
 def _data(
-    form: FormElement, data: FormdataType, click_element: HtmlElement | None
+    form: FormElement,
+    data: FormdataType,
+    click_element: HtmlElement | None,
+    ignore_disabled: bool,
 ) -> list[tuple[str, str]]:
     data = data or {}
     if click_element is not None and (name := click_element.get("name")):
@@ -153,6 +181,8 @@ def _data(
         '  not(re:test(., "^(?:checkbox|radio)$", "i")))]]',
         namespaces={"re": "http://exslt.org/regular-expressions"},
     )
+    if ignore_disabled:
+        inputs = [e for e in inputs if not _is_element_disabled(e)]
     values: list[FormdataKVType] = [
         (k, "" if v is None else v)
         for k, v in (
@@ -243,6 +273,7 @@ def form2request(
     click: bool | HtmlElement | Selector | SelectorList | None = None,
     method: None | str = None,
     enctype: None | str = None,
+    ignore_disabled: bool = True,
 ) -> Request:
     """Return request data for an HTML form submission.
 
@@ -277,14 +308,20 @@ def form2request(
         may be necessary.
 
     *method* and *enctype* may be used to override matching form attributes.
+
+    *ignore_disabled* controls whether disabled form elements are excluded from
+    the request data and from auto-detection of the submit button. It defaults
+    to ``True``, which matches browser behavior. Set it to ``False`` to include
+    disabled elements, which can be useful when fields are enabled dynamically
+    through JavaScript before submission.
     """
     form_el = cast("FormElement", _parsel_to_lxml(form))
-    click_element = _click_element(form_el, click)
+    click_element = _click_element(form_el, click, ignore_disabled)
     url = _url(form_el, click_element)
     method = _method(form_el, click_element, method)
     headers = []
     body = ""
-    data = _data(form_el, data, click_element)
+    data = _data(form_el, data, click_element, ignore_disabled)
     if method == "GET":
         url = urlunsplit(urlsplit(url)._replace(query=urlencode(data, doseq=True)))
     else:

--- a/form2request/_base.py
+++ b/form2request/_base.py
@@ -248,11 +248,9 @@ class Request:
         return request.prepare()
 
     def to_scrapy(self, callback: Callable, **kwargs: Any):
-        """Convert the request to :class:`scrapy.Request
-        <scrapy.http.Request>`.
+        """Convert the request to :class:`scrapy.Request`.
 
-        All *kwargs* are passed to :class:`scrapy.Request
-        <scrapy.http.Request>` as is.
+        All *kwargs* are passed to :class:`scrapy.Request` as is.
         """
         import scrapy
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -540,8 +540,8 @@ from form2request import Request, form2request
                 b"",
             ),
         ),
-        # We currently do not support ignoring disabled form elements.
-        pytest.param(
+        # Disabled elements are excluded.
+        (
             "https://example.com",
             b"""<form><input disabled name="a" value="b"></form>""",
             {},
@@ -551,9 +551,8 @@ from form2request import Request, form2request
                 [],
                 b"",
             ),
-            marks=pytest.mark.xfail(reason="No disabled support"),
         ),
-        pytest.param(
+        (
             "https://example.com",
             b"""<form><fieldset disabled><input name="a" value="b">
             </fieldset></form>""",
@@ -564,7 +563,81 @@ from form2request import Request, form2request
                 [],
                 b"",
             ),
-            marks=pytest.mark.xfail(reason="No disabled support"),
+        ),
+        # Elements inside the first legend of a disabled fieldset are not disabled.
+        (
+            "https://example.com",
+            b"""<form><fieldset disabled><legend><input name="a" value="b">
+            </legend></fieldset></form>""",
+            {},
+            Request(
+                "https://example.com?a=b",
+                "GET",
+                [],
+                b"",
+            ),
+        ),
+        # Elements inside a later legend of a disabled fieldset are disabled.
+        (
+            "https://example.com",
+            b"""<form><fieldset disabled><legend>L1</legend>
+            <legend><input name="a" value="b"></legend></fieldset></form>""",
+            {},
+            Request(
+                "https://example.com",
+                "GET",
+                [],
+                b"",
+            ),
+        ),
+        # A disabled submit button is skipped during auto-detection.
+        (
+            "https://example.com",
+            b"""<form><input type="submit" disabled name="a" value="b" /></form>""",
+            {},
+            Request(
+                "https://example.com",
+                "GET",
+                [],
+                b"",
+            ),
+        ),
+        # ignore_disabled=False includes disabled elements.
+        (
+            "https://example.com",
+            b"""<form><input disabled name="a" value="b"></form>""",
+            {"ignore_disabled": False},
+            Request(
+                "https://example.com?a=b",
+                "GET",
+                [],
+                b"",
+            ),
+        ),
+        # ignore_disabled=False includes elements in a disabled fieldset.
+        (
+            "https://example.com",
+            b"""<form><fieldset disabled><input name="a" value="b">
+            </fieldset></form>""",
+            {"ignore_disabled": False},
+            Request(
+                "https://example.com?a=b",
+                "GET",
+                [],
+                b"",
+            ),
+        ),
+        # ignore_disabled=False picks up a disabled submit button.
+        (
+            "https://example.com",
+            b"""<form><input type="submit" disabled name="a" value="b" /></form>""",
+            {"ignore_disabled": False},
+            Request(
+                "https://example.com?a=b",
+                "GET",
+                [],
+                b"",
+            ),
         ),
         # Single-choice select with a single option.
         (


### PR DESCRIPTION
Fixes #7.

I am not sure what the default behavior should be, though.

This PR currently changes the previous behavior, i.e. it is a **breaking change**. The new behavior follows the same criteria as browsers. But browsers work with JavaScript, and JavaScript can enable elements; form2request cannot. It can be fed a browser-rendered HTML, thought.